### PR TITLE
ARIOS-1871 - Preview videos stop working suddenly without any reason

### DIFF
--- a/Sources/HTTPServerNonblocking.swift
+++ b/Sources/HTTPServerNonblocking.swift
@@ -100,15 +100,21 @@ public class HTTPServerNonblocking: HttpServer {
                                 #endif
                                 if !keepConnection {
                                     socket.close()
-                                    poll_set[position].fd = -1
-                                    poll_set[position].events = 0
-                                    poll_set[position].revents = 0
                                 }
                             }
                             
                         } // END handle data from client
                     } // END got new incoming connection
                 } // END looping through file descriptors
+                
+                var i = 0
+                while i < poll_set.count {
+                    if (poll_set[i].fd == -1) {
+                        poll_set.remove(at: i)
+                        i -= 1
+                    }
+                    i += 1
+                }
             } // END for(;;)--and you thought it would never end!
         }
         self.state = .running


### PR DESCRIPTION
File descriptors in the poll array can be removed after they have been used. This keeps the array small. Without this, there would be cases where the array would grow a lot after using the app for a long time and this would cause the code for checking the sockets to gradually take more and more time and CPU usage.